### PR TITLE
Fix Optimism tab in Deployment Addresses

### DIFF
--- a/docs/Developers/Deployment Addresses.mdx
+++ b/docs/Developers/Deployment Addresses.mdx
@@ -84,9 +84,9 @@ Below is a list of our core contracts and their addresses across _all_ of the ch
 
 </TabItem>
 
-<TabItem value='avax' label='Avalanche'>
-
 <TabItem value='optimism' label='Optimism'>
+  
+### Optimism
 
 | Name                               | Address                                      | Source Code                                                                                                                   |
 | :--------------------------------- | :------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------- |
@@ -97,6 +97,8 @@ Below is a list of our core contracts and their addresses across _all_ of the ch
 | `TridentSushiRollCP`               | `0x1be211D8DA40BC0ae8719c6663307Bfc987b1d6c` | [Code](https://github.com/sushiswap/trident/blob/master/contracts/migration/TridentSushiRollCP.sol)                           |
 
 </TabItem>
+  
+<TabItem value='avax' label='Avalanche'>
 
 ### Avalanche (Mainnet C-Chain)
 


### PR DESCRIPTION
The avalanche tag for the tap item was on the wrong place. Additionally the header for Optimism was missing.