### PR TITLE
Fix bento deployment addresses

### DIFF
--- a/docs/Developers/Deployment Addresses.mdx
+++ b/docs/Developers/Deployment Addresses.mdx
@@ -49,7 +49,7 @@ Below is a list of our core contracts and their addresses across _all_ of the ch
 | `MiniChefV2`                       | `0x0769fd68dFb93167989C6f7254cd0D766Fb2841F` | [Code](https://github.com/sushiswap/sushiswap/blob/archieve/canary/contracts/MiniChefV2.sol)                                           |
 | `SushiV2Factory`                   | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol)                           |
 | `SushiSwapRouter`                  | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol)                          |
-| `BentoBoxV1`                       | `0xe2f736B7d1f6071124CBb5FC23E93d141CD24E12` | [Code](https://github.com/sushiswap/sushiswap/blob/canary/contracts/bentobox/BentoBoxV1.sol)                                  |
+| `BentoBoxV1`                       | `0x0319000133d3AdA02600f0875d2cf03D442C3367` | [Code](https://github.com/sushiswap/sushiswap/blob/canary/contracts/bentobox/BentoBoxV1.sol)                                  |
 | `ComplexRewarderTime`              | `0xa3378Ca78633B3b9b2255EAa26748770211163AE` | [Code](https://github.com/sushiswap/sushiswap/blob/canary/contracts/mocks/ComplexRewarderTime.sol)                            |
 | `SushiRoll`                        | `0x0053957E18A0994D3526Cf879A4cA7Be88e8936A` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/SushiRoll.sol)                                            |
 | `SushiToken`                       | `0x0b3F868E0BE5597D5DB7fEB59E1CADBb0fdDa50a` | [Code](https://github.com/sushiswap/sushiswap/blob/archieve/canary/contracts/SushiToken.sol)                                           |
@@ -66,6 +66,7 @@ Below is a list of our core contracts and their addresses across _all_ of the ch
 | `MiniChefV2`      | `0x0769fd68dFb93167989C6f7254cd0D766Fb2841F` | [Code](https://github.com/sushiswap/sushiswap/blob/archieve/canary/contracts/MiniChefV2.sol)                  |
 | `SushiV2Factory`  | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol)  |
 | `SushiSwapRouter` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) |
+| `BentoBoxV1`      | `0xF5BCE5077908a1b7370B9ae04AdC565EBd643966` | [Code](https://github.com/sushiswap/sushiswap/blob/canary/contracts/bentobox/BentoBoxV1.sol)         |
 
 </TabItem>
 
@@ -78,7 +79,7 @@ Below is a list of our core contracts and their addresses across _all_ of the ch
 | `MiniChefV2`      | `0xF4d73326C13a4Fc5FD7A064217e12780e9Bd62c3` | [Code](https://github.com/sushiswap/sushiswap/blob/archieve/canary/contracts/MiniChefV2.sol)                  |
 | `SushiV2Factory`  | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol)  |
 | `SushiSwapRouter` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) |
-| `BentoBox`      | `0xB5891167796722331b7ea7824F036b3Bdcb4531C` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/bentobox/v1/contracts/BentoBox.sol)         |
+| `BentoBox`        | `0x74c764D41B77DBbb4fe771daB1939B00b146894A` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/bentobox/v1/contracts/BentoBox.sol)         |
 | `Multicall2`      | `0x80C7DD17B01855a6D2347444a0FCC36136a314de` | [Code](https://github.com/sushiswap/sushiswap/blob/canary/contracts/Multicall2.sol)                  |
 | `SushiToken`      | `0xd4d42F0b6DEF4CE0383636770eF773390d85c61A` | [Code](https://github.com/sushiswap/sushiswap/blob/archieve/canary/contracts/SushiToken.sol)                  |
 
@@ -93,6 +94,7 @@ Below is a list of our core contracts and their addresses across _all_ of the ch
 | `SushiV2Factory`  | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol)  |
 | `SushiSwapRouter` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) |
 | `SushiToken`      | `0x37B608519F91f70F2EeB0e5Ed9AF4061722e4F76` | [Code](https://github.com/sushiswap/sushiswap/blob/archieve/canary/contracts/SushiToken.sol)                  |
+| `BentoBoxV1`      | `0x0711b6026068f736bae6b213031fce978d48e026` | [Code](https://github.com/sushiswap/sushiswap/blob/canary/contracts/bentobox/BentoBoxV1.sol)         |                  |
 
 ### Testnet (Fuji)
 
@@ -127,6 +129,7 @@ Below is a list of our core contracts and their addresses across _all_ of the ch
 | `SushiV2Factory`      | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol)  |
 | `SushiSwapRouter`     | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) |
 | `ComplexRewarderTime` | `0x1334c8e873E1cae8467156e2A81d1C8b566B2da1` | [Code](https://github.com/sushiswap/sushiswap/blob/canary/contracts/mocks/ComplexRewarderTime.sol)   |
+| `BentoBoxV1`          | `0x145d82bCa93cCa2AE057D1c6f26245d1b9522E6F` | [Code](https://github.com/sushiswap/sushiswap/blob/canary/contracts/bentobox/BentoBoxV1.sol)         |
 
 </TabItem>
 
@@ -138,7 +141,7 @@ Below is a list of our core contracts and their addresses across _all_ of the ch
 | :---------------- | :------------------------------------------- | :--------------------------------------------------------------------------------------------------- |
 | `SushiV2Factory`  | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol)  |
 | `SushiSwapRouter` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) |
-| `BentoBoxV1`      | `0xB5891167796722331b7ea7824F036b3Bdcb4531C` | [Code](https://github.com/sushiswap/sushiswap/blob/canary/contracts/bentobox/BentoBoxV1.sol)         |
+| `BentoBoxV1`      | `0xF5BCE5077908a1b7370B9ae04AdC565EBd643966` | [Code](https://github.com/sushiswap/sushiswap/blob/canary/contracts/bentobox/BentoBoxV1.sol)         |
 | `SushiToken`      | `0xae75A438b2E0cB8Bb01Ec1E1e376De11D44477CC` | [Code](https://github.com/sushiswap/sushiswap/blob/archieve/canary/contracts/SushiToken.sol)                  |
 
 </TabItem>
@@ -151,7 +154,7 @@ Below is a list of our core contracts and their addresses across _all_ of the ch
 | :---------------- | :------------------------------------------- | :--------------------------------------------------------------------------------------------------- |
 | `SushiV2Factory`  | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol)  |
 | `SushiSwapRouter` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) |
-| `BentoBox`      | `0xB5891167796722331b7ea7824F036b3Bdcb4531C` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/bentobox/v1/contracts/BentoBox.sol)         |
+| `BentoBox`        | `0xF5BCE5077908a1b7370B9ae04AdC565EBd643966` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/bentobox/v1/contracts/BentoBox.sol)         |
 | `SushiRoll`       | `0x2DD1aB1956BeD7C2d938d0d7378C22Fd01135a5e` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/SushiRoll.sol)                   |
 | `SushiToken`      | `0x947950BcC74888a40Ffa2593C5798F11Fc9124C4` | [Code](https://github.com/sushiswap/sushiswap/blob/archieve/canary/contracts/SushiToken.sol)                  |
 
@@ -172,7 +175,7 @@ Below is a list of our core contracts and their addresses across _all_ of the ch
 | `MiniChefV2`      | `0xdDCbf776dF3dE60163066A5ddDF2277cB445E0F3` | [Code](https://github.com/sushiswap/sushiswap/blob/archieve/canary/contracts/MiniChefV2.sol)                  |
 | `SushiV2Factory`  | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol)  |
 | `SushiSwapRouter` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) |
-| `BentoBox`      | `0xE2d7F5dd869Fc7c126D21b13a9080e75a4bDb324` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/bentobox/v1/contracts/BentoBox.sol)         |
+| `BentoBox`        | `0xE2d7F5dd869Fc7c126D21b13a9080e75a4bDb324` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/bentobox/v1/contracts/BentoBox.sol)         |
 | `SushiToken`      | `0x2995D1317DcD4f0aB89f4AE60F3f020A4F17C7CE` | [Code](https://github.com/sushiswap/sushiswap/blob/archieve/canary/contracts/SushiToken.sol)                  |
 
 </TabItem>
@@ -187,6 +190,7 @@ Below is a list of our core contracts and their addresses across _all_ of the ch
 | `SushiV2Factory`  | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol)  |
 | `SushiSwapRouter` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) |
 | `SushiToken`      | `0xBEC775Cb42AbFa4288dE81F387a9b1A3c4Bc552A` | [Code](https://github.com/sushiswap/sushiswap/blob/archieve/canary/contracts/SushiToken.sol)                  |
+| `BentoBoxV1`      | `0xA28cfF72b04f83A7E3f912e6ad34d5537708a2C2` | [Code](https://github.com/sushiswap/sushiswap/blob/canary/contracts/bentobox/BentoBoxV1.sol)         |
 
 ### Testnet
 
@@ -278,6 +282,7 @@ Below is a list of our core contracts and their addresses across _all_ of the ch
 | `SushiV2Factory`  | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol)  |
 | `SushiSwapRouter` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) |
 | `Multicall2`      | `0x0769fd68dFb93167989C6f7254cd0D766Fb2841F` | [Code](https://github.com/sushiswap/sushiswap/blob/canary/contracts/Multicall2.sol)                  |
+| `BentoBoxV1`      | `0x80C7DD17B01855a6D2347444a0FCC36136a314de` | [Code](https://github.com/sushiswap/sushiswap/blob/canary/contracts/bentobox/BentoBoxV1.sol)         |
 
 </TabItem>
 


### PR DESCRIPTION
Using addresses from sdk : https://github.com/sushiswap/sdk/blob/canary/packages/core-sdk/src/constants/addresses.ts