### PR TITLE
Update Deployment Addresses.mdx

### DIFF
--- a/docs/Developers/Deployment Addresses.mdx
+++ b/docs/Developers/Deployment Addresses.mdx
@@ -5,6 +5,8 @@ import TabItem from '@theme/TabItem';
 
 Below is a list of our core contracts and their addresses across _all_ of the chains you can find us on.
 
+*Testnet deployments will use the same router/factory contract addresses as their mainnet deployments*
+
 <Tabs>
 
 <TabItem value='eth' label='Ethereum' default>
@@ -97,7 +99,7 @@ Below is a list of our core contracts and their addresses across _all_ of the ch
 
 <TabItem value='arbitrum' label='Arbitrum'>
 
-### Arbitrum
+### Arbitrum Nitro
 
 | Name | Address | Source Code | Explorer |
 | :-- | :-- | :-- | :-- |
@@ -113,6 +115,14 @@ Below is a list of our core contracts and their addresses across _all_ of the ch
 | `FuroStreamRouter` | `0xf30CF8D373D78D7964A2F7793b730BF7ae0970a8` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/furo/contracts/FuroStreamRouter.sol) | [Link](https://arbiscan.io/address/0xf30CF8D373D78D7964A2F7793b730BF7ae0970a8)|
 | `FuroVesting` | `0x0689640d190b10765f09310fCfE9C670eDe4E25B` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/furo/contracts/base/FuroVesting.sol) | [Link](https://arbiscan.io/address/0x0689640d190b10765f09310fCfE9C670eDe4E25B)|
 | `FuroVestingRouter` | `0x312A8E33d78d3Ab79E62971E86e5e8c9c5E28D64` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/furo/contracts/FuroVestingRouter.sol) | [Link](https://arbiscan.io/address/0x312A8E33d78d3Ab79E62971E86e5e8c9c5E28D64)|
+  
+### Arbitrum Nova
+  
+| Name | Address | Source Code | Explorer |
+| :-- | :-- | :-- | :-- |
+| `SushiV2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol) | [Link](https://nova.arbiscan.io/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
+| `SushiSwapRouter` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) | [Link](https://nova.arbiscan.io/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
+| `SushiToken` | `0xfe60A48a0bCf4636aFEcC9642a145D2F241A7011` | [Code](https://github.com/sushiswap/sushiswap/blob/archieve/canary/contracts/SushiToken.sol) | [Link](https://nova.arbiscan.io/token/0xfe60a48a0bcf4636afecc9642a145d2f241a7011) |
   
 </TabItem>
 
@@ -239,6 +249,7 @@ Below is a list of our core contracts and their addresses across _all_ of the ch
 | `MiniChefV2` | `0x3dB01570D97631f69bbb0ba39796865456Cf89A5` | [Code](https://github.com/sushiswap/sushiswap/blob/archieve/canary/contracts/MiniChefV2.sol) | [Link](https://moonriver.moonscan.io/address/0x3db01570d97631f69bbb0ba39796865456cf89a5) |
 | `SushiV2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol) | [Link](https://moonriver.moonscan.io/address/0xc35dadb65012ec5796536bd9864ed8773abc74c4) |
 | `SushiSwapRouter` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) | [Link](https://moonriver.moonscan.io/address/0x1b02da8cb0d097eb8d57a175b88c7d8b47997506) |
+| `SushiToken` | `0xf390830df829cf22c53c8840554b98eafc5dcbc2` | [Code](https://github.com/sushiswap/sushiswap/blob/archieve/canary/contracts/SushiToken.sol) | [Link](https://moonriver.moonscan.io/token/0xf390830df829cf22c53c8840554b98eafc5dcbc2) |
 | `ComplexRewarderTime` | `0x1334c8e873E1cae8467156e2A81d1C8b566B2da1` | [Code](https://github.com/sushiswap/sushiswap/blob/canary/contracts/mocks/ComplexRewarderTime.sol) | [Link](https://moonriver.moonscan.io/address/0x1334c8e873e1cae8467156e2a81d1c8b566b2da1) |
 | `BentoBoxV1` | `0x145d82bCa93cCa2AE057D1c6f26245d1b9522E6F` | [Code](https://github.com/sushiswap/sushiswap/blob/canary/contracts/bentobox/BentoBoxV1.sol) | [Link](https://moonriver.moonscan.io/address/0x145d82bca93cca2ae057d1c6f26245d1b9522e6f) |
 | `WethMaker` | `0x1c8FA2f5f7520Eef45B7E4816687AF0e8E991760` | [Code](https://github.com/sushiswap/unwindooor/blob/1657c857144ba8fd18d3eaf16895f702512057a6/contracts/WethMaker.sol) | [Link](https://moonriver.moonscan.io/address/0x1c8fa2f5f7520eef45b7e4816687af0e8e991760) |
@@ -283,14 +294,6 @@ Below is a list of our core contracts and their addresses across _all_ of the ch
 | `FuroStream` | `0x4ab2FC6e258a0cA7175D05fF10C5cF798A672cAE` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/furo/contracts/base/FuroStream.sol) | [Link](https://explorer.harmony.one/address/0x4ab2fc6e258a0ca7175d05ff10c5cf798a672cae)|
 | `FuroVesting` | `0x0689640d190b10765f09310fCfE9C670eDe4E25B` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/furo/contracts/base/FuroVesting.sol) | [Link](https://explorer.harmony.one/address/0x0689640d190b10765f09310fCfE9C670eDe4E25B)
 
-### Testnet
-
-| Name | Address | Source Code |
-| :-- | :-- | :-- |
-| `MiniChefV2` | `0x67dA5f2FfaDDfF067AB9d5F025F8810634d84287` | [Code](https://github.com/sushiswap/sushiswap/blob/archieve/canary/contracts/MiniChefV2.sol) |
-| `SushiV2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol) |
-| `SushiSwapRouter` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) |
-
 </TabItem>
 
 <TabItem value='telos' label='Telos'>
@@ -301,7 +304,8 @@ Below is a list of our core contracts and their addresses across _all_ of the ch
 | :-- | :-- | :-- | :-- |
 | `SushiV2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol) | [Link](https://www.teloscan.io/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4/) |
 | `SushiSwapRouter` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) | [Link](https://www.teloscan.io/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
-
+| `SushiToken` | `0x922D641a426DcFFaeF11680e5358F34d97d112E1` | [Code](https://github.com/sushiswap/sushiswap/blob/archieve/canary/contracts/SushiToken.sol) | [Link](https://www.teloscan.io/address/0x922D641a426DcFFaeF11680e5358F34d97d112E1) |
+  
 </TabItem>
 
 <TabItem value='metis' label='Metis'>
@@ -337,19 +341,20 @@ Below is a list of our core contracts and their addresses across _all_ of the ch
   
 </TabItem>
 
-<TabItem value='kava' label='KAVA'>
+<TabItem value='kava' label='Kava'>
   
 ### Kava
 
-| Name | Address | Source Code |
-| :-- | :-- | :-- |
-| `MiniChefV2` | `0xf731202A3cf7EfA9368C2d7bD613926f7A144dB5` | [Code](https://github.com/sushiswap/sushiswap/blob/archieve/canary/contracts/MiniChefV2.sol) |
-| `ComplexRewarderTime` | `0xeaf76e3bD36680D98d254B378ED706cb0DFBfc1B` | [Code](https://github.com/sushiswap/sushiswap/blob/canary/contracts/mocks/ComplexRewarderTime.sol) |
-| `TridentRouter` | `0xbE811A0D44E2553d25d11CB8DC0d3F0D0E6430E6` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) |
+| Name | Address | Source Code | Explorer |
+| :-- | :-- | :-- | :-- |
+| `MiniChefV2` | `0xf731202A3cf7EfA9368C2d7bD613926f7A144dB5` | [Code](https://github.com/sushiswap/sushiswap/blob/archieve/canary/contracts/MiniChefV2.sol) | [Link](https://explorer.kava.io/address/0xf731202A3cf7EfA9368C2d7bD613926f7A144dB5/transactions) |
+| `ComplexRewarderTime` | `0xeaf76e3bD36680D98d254B378ED706cb0DFBfc1B` | [Code](https://github.com/sushiswap/sushiswap/blob/canary/contracts/mocks/ComplexRewarderTime.sol) | [Link](https://explorer.kava.io/address/0xeaf76e3bD36680D98d254B378ED706cb0DFBfc1B/transactions) |
+| `TridentRouter` | `0xbE811A0D44E2553d25d11CB8DC0d3F0D0E6430E6` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) | [Link](https://explorer.kava.io/address/0xbE811A0D44E2553d25d11CB8DC0d3F0D0E6430E6/transactions) |
+| `SushiToken` | `0x7C598c96D02398d89FbCb9d41Eab3DF0C16F227D` | [Code](https://github.com/sushiswap/sushiswap/blob/archieve/canary/contracts/SushiToken.sol) | [Link](https://explorer.kava.io/address/0x7C598c96D02398d89FbCb9d41Eab3DF0C16F227D/transactions) |
   
 </TabItem>
 
-<TabItem value='boba' label='BOBA'>
+<TabItem value='boba' label='Boba'>
   
 ### Boba
 
@@ -358,8 +363,9 @@ Below is a list of our core contracts and their addresses across _all_ of the ch
 | `MiniChefV2` | `0x75f52766a6a23f736edefcd69dfbe6153a48c3f3` | [Code](https://github.com/sushiswap/sushiswap/blob/archieve/canary/contracts/MiniChefV2.sol) | [Link](https://bobascan.com/address/0x75f52766a6a23f736edefcd69dfbe6153a48c3f3#code) |
 | `ComplexRewarderTime` | `0xf731202a3cf7efa9368c2d7bd613926f7a144db5` | [Code](https://github.com/sushiswap/sushiswap/blob/canary/contracts/mocks/ComplexRewarderTime.sol) | [Link](https://bobascan.com/address/0xf731202a3cf7efa9368c2d7bd613926f7a144db5) |
 | `SushiV2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol) | [Link](https://bobascan.com/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
-| `SushiSwapRouter` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) | [Link](https://bobascan.com/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |  
-
+| `SushiSwapRouter` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) | [Link](https://bobascan.com/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
+| `SushiToken` | `0x5ffccc55c0d2fd6d3ac32c26c020b3267e933f1b` | [Code](https://github.com/sushiswap/sushiswap/blob/archieve/canary/contracts/SushiToken.sol) | [Link](https://bobascan.com/token/0x5ffccc55c0d2fd6d3ac32c26c020b3267e933f1b) |
+  
 </TabItem>
 
 <TabItem value='fuse' label='Fuse'>
@@ -385,13 +391,6 @@ Below is a list of our core contracts and their addresses across _all_ of the ch
 | :-- | :-- | :-- | :-- |
 | `SushiV2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol) | [Link](https://www.oklink.com/en/okc/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
 | `SushiSwapRouter` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) | [Link](https://www.oklink.com/en/okc/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
-
-### Testnet
-
-| Name | Address | Source Code |
-| :-- | :-- | :-- |
-| `SushiV2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol) |
-| `SushiSwapRouter` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) |
   
 </TabItem>
 
@@ -415,13 +414,6 @@ Below is a list of our core contracts and their addresses across _all_ of the ch
 | `SushiV2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol) | [Link](https://explorer.palm.io/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4/transactions) |
 | `SushiSwapRouter` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) | [Link](https://explorer.palm.io/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506/transactions) |
 | `Multicall2` | `0x0769fd68dFb93167989C6f7254cd0D766Fb2841F` | [Code](https://github.com/sushiswap/sushiswap/blob/canary/contracts/Multicall2.sol) | [Link](https://explorer.palm.io/address/0x0769fd68dFb93167989C6f7254cd0D766Fb2841F/transactions) |
-
-### Testnet
-
-| Name | Address | Source Code |
-| :-- | :-- | :-- |
-| `SushiV2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol) |
-| `SushiSwapRouter` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) |
 
 </TabItem>
 


### PR DESCRIPTION
Added Arbitrum Nova section, cleaned off redundant testnet sections on rarely used chains, and included missing Sushi token addresses for various networks.