### PR TITLE
update MasterChefV2 Deployment Addresses.mdx

### DIFF
--- a/docs/Products/Chefs & Farms/MasterChefV2/Deployment Addresses.mdx
+++ b/docs/Products/Chefs & Farms/MasterChefV2/Deployment Addresses.mdx
@@ -13,7 +13,7 @@ Below is a list of the contracts related to MasterChefV2.
 
 | Name | Address | Source Code | Explorer |
 | :-- | :-- | :-- | :-- |
-| `MasterChefV2` | `0xbE811A0D44E2553d25d11CB8DC0d3F0D0E6430E6` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/masterchef/contracts/MasterChefV2.sol) | [Link](https://etherscan.io/address/0xef0881ec094552b2e128cf945ef17a6752b4ec5d) |
+| `MasterChefV2` | `0xef0881ec094552b2e128cf945ef17a6752b4ec5d` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/masterchef/contracts/MasterChefV2.sol) | [Link](https://etherscan.io/address/0xef0881ec094552b2e128cf945ef17a6752b4ec5d) |
 
 </TabItem>
 


### PR DESCRIPTION
Updated the deployment address for the MasterChefV2 contract, the link was correct but it was showing the wrong one.