### PR TITLE
Updated V2Router urls in docs

### DIFF
--- a/docs/Products/Classic AMM/Contracts/V2Router02.md
+++ b/docs/Products/Classic AMM/Contracts/V2Router02.md
@@ -6,7 +6,7 @@ sidebar_position: 4
 
 V2Router02 is used as a intermediate contract to interact with liquidity pools, or the lower level V2Pair contract. The contract can be used to swap, add liquidity, withdraw liquidity. The contract also contains many variations of these three tasks that can be used for each unique situation like using native gas tokens (i.e. ETH), and Fee-On-Transfer tokens with a tax when transfers happen.
 
-The full contract can be found [here](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol).
+The full contract can be found [here](https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol).
 
 ## Read-Only Functions
 

--- a/docs/Products/Classic AMM/Deployment Addresses.mdx
+++ b/docs/Products/Classic AMM/Deployment Addresses.mdx
@@ -13,8 +13,8 @@ Below is a list of the V2Factory and V2Router02 contracts deployed.
 
 | Name | Address | Source Code | Explorer |
 | :-- | :-- | :-- | :-- |
-| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol) | [Link](https://nova.arbiscan.io/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
-| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) | [Link](https://nova.arbiscan.io/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
+| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://nova.arbiscan.io/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
+| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://nova.arbiscan.io/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
 
 </TabItem>
 
@@ -24,8 +24,8 @@ Below is a list of the V2Factory and V2Router02 contracts deployed.
 
 | Name | Address | Source Code | Explorer |
 | :-- | :-- | :-- | :-- |
-| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol) | [Link](https://arbiscan.io/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
-| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) | [Link](https://arbiscan.io/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
+| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://arbiscan.io/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
+| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://arbiscan.io/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
 
 </TabItem>
 
@@ -35,8 +35,8 @@ Below is a list of the V2Factory and V2Router02 contracts deployed.
 
 | Name | Address | Source Code | Explorer |
 | :-- | :-- | :-- | :-- |
-| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol) | [Link](https://snowtrace.io/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
-| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) | [Link](https://snowtrace.io/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
+| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://snowtrace.io/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
+| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://snowtrace.io/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
 
 </TabItem>
 
@@ -46,8 +46,8 @@ Below is a list of the V2Factory and V2Router02 contracts deployed.
 
 | Name | Address | Source Code | Explorer |
 | :-- | :-- | :-- | :-- |
-| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol) | [Link](https://testnet.snowtrace.io/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
-| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) | [Link](https://testnet.snowtrace.io/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
+| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://testnet.snowtrace.io/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
+| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://testnet.snowtrace.io/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
 
 </TabItem>
 
@@ -57,8 +57,8 @@ Below is a list of the V2Factory and V2Router02 contracts deployed.
 
 | Name | Address | Source Code | Explorer |
 | :-- | :-- | :-- | :-- |
-| `V2Factory` | `0x71524B4f93c58fcbF659783284E38825f0622859` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol) | [Link](https://basescan.org/address/0x71524b4f93c58fcbf659783284e38825f0622859) |
-| `V2Router02` | `0x6BDED42c6DA8FBf0d2bA55B2fa120C5e0c8D7891` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) | [Link](https://basescan.org/address/0x6bded42c6da8fbf0d2ba55b2fa120c5e0c8d7891) |
+| `V2Factory` | `0x71524B4f93c58fcbF659783284E38825f0622859` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://basescan.org/address/0x71524b4f93c58fcbf659783284e38825f0622859) |
+| `V2Router02` | `0x6BDED42c6DA8FBf0d2bA55B2fa120C5e0c8D7891` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://basescan.org/address/0x6bded42c6da8fbf0d2ba55b2fa120c5e0c8d7891) |
 
 </TabItem>
 
@@ -68,8 +68,8 @@ Below is a list of the V2Factory and V2Router02 contracts deployed.
 
 | Name | Address | Source Code | Explorer |
 | :-- | :-- | :-- | :-- |
-| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol) | [Link](https://bobascan.com/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
-| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) | [Link](https://bobascan.com/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
+| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://bobascan.com/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
+| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://bobascan.com/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
 
 </TabItem>
 
@@ -79,8 +79,8 @@ Below is a list of the V2Factory and V2Router02 contracts deployed.
 
 | Name | Address | Source Code | Explorer |
 | :-- | :-- | :-- | :-- |
-| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol) | [Link](https://blockexplorer.avax.boba.network/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
-| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) | [Link](https://blockexplorer.avax.boba.network/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
+| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://blockexplorer.avax.boba.network/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
+| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://blockexplorer.avax.boba.network/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
 
 </TabItem>
 
@@ -90,8 +90,8 @@ Below is a list of the V2Factory and V2Router02 contracts deployed.
 
 | Name | Address | Source Code | Explorer |
 | :-- | :-- | :-- | :-- |
-| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol) | [Link](https://blockexplorer.bnb.boba.network/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
-| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) | [Link](https://blockexplorer.bnb.boba.network/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
+| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://blockexplorer.bnb.boba.network/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
+| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://blockexplorer.bnb.boba.network/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
 
 </TabItem>
 
@@ -101,8 +101,8 @@ Below is a list of the V2Factory and V2Router02 contracts deployed.
 
 | Name | Address | Source Code | Explorer |
 | :-- | :-- | :-- | :-- |
-| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol) | [Link](https://bscscan.com/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
-| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) | [Link](https://bscscan.com/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
+| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://bscscan.com/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
+| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://bscscan.com/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
 
 </TabItem>
 
@@ -112,8 +112,8 @@ Below is a list of the V2Factory and V2Router02 contracts deployed.
 
 | Name | Address | Source Code | Explorer |
 | :-- | :-- | :-- | :-- |
-| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol) | [Link](https://testnet.bscscan.com/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
-| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) | [Link](https://testnet.bscscan.com/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
+| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://testnet.bscscan.com/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
+| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://testnet.bscscan.com/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
 
 </TabItem>
 
@@ -123,8 +123,8 @@ Below is a list of the V2Factory and V2Router02 contracts deployed.
 
 | Name | Address | Source Code | Explorer |
 | :-- | :-- | :-- | :-- |
-| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol) | [Link](https://celoscan.io/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
-| `V2Router02` | `0x1421bDe4B10e8dd459b3BCb598810B1337D56842` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) | [Link](https://celoscan.io/address/0x1421bDe4B10e8dd459b3BCb598810B1337D56842) |
+| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://celoscan.io/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
+| `V2Router02` | `0x1421bDe4B10e8dd459b3BCb598810B1337D56842` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://celoscan.io/address/0x1421bDe4B10e8dd459b3BCb598810B1337D56842) |
 
 </TabItem>
 
@@ -134,8 +134,8 @@ Below is a list of the V2Factory and V2Router02 contracts deployed.
 
 | Name | Address | Source Code | Explorer |
 | :-- | :-- | :-- | :-- |
-| `V2Factory` | `0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol) | [Link](https://etherscan.io/address/0xc0aee478e3658e2610c5f7a4a2e1777ce9e4f2ac) |
-| `V2Router02` | `0xd9e1cE17f2641f24aE83637ab66a2cca9C378B9F` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) | [Link](https://etherscan.io/address/0xd9e1cE17f2641f24aE83637ab66a2cca9C378B9F) |
+| `V2Factory` | `0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://etherscan.io/address/0xc0aee478e3658e2610c5f7a4a2e1777ce9e4f2ac) |
+| `V2Router02` | `0xd9e1cE17f2641f24aE83637ab66a2cca9C378B9F` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://etherscan.io/address/0xd9e1cE17f2641f24aE83637ab66a2cca9C378B9F) |
 
 </TabItem>
 
@@ -145,8 +145,8 @@ Below is a list of the V2Factory and V2Router02 contracts deployed.
 
 | Name | Address | Source Code | Explorer |
 | :-- | :-- | :-- | :-- |
-| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol) | [Link](https://ftmscan.com/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
-| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) | [Link](https://ftmscan.com/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
+| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://ftmscan.com/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
+| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://ftmscan.com/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
 
 </TabItem>
 
@@ -156,8 +156,8 @@ Below is a list of the V2Factory and V2Router02 contracts deployed.
 
 | Name | Address | Source Code | Explorer |
 | :-- | :-- | :-- | :-- |
-| `V2Factory` | `0x43eA90e2b786728520e4f930d2A71a477BF2737C` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol) | [Link](https://explorer.fuse.io/address/0x43eA90e2b786728520e4f930d2A71a477BF2737C) |
-| `V2Router02` | `0xF4d73326C13a4Fc5FD7A064217e12780e9Bd62c3` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) | [Link](https://explorer.fuse.io/address/0xF4d73326C13a4Fc5FD7A064217e12780e9Bd62c3) |
+| `V2Factory` | `0x43eA90e2b786728520e4f930d2A71a477BF2737C` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://explorer.fuse.io/address/0x43eA90e2b786728520e4f930d2A71a477BF2737C) |
+| `V2Router02` | `0xF4d73326C13a4Fc5FD7A064217e12780e9Bd62c3` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://explorer.fuse.io/address/0xF4d73326C13a4Fc5FD7A064217e12780e9Bd62c3) |
 
 </TabItem>
 
@@ -167,8 +167,8 @@ Below is a list of the V2Factory and V2Router02 contracts deployed.
 
 | Name | Address | Source Code | Explorer |
 | :-- | :-- | :-- | :-- |
-| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol) | [Link](https://goerli.etherscan.io/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
-| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) | [Link](https://goerli.etherscan.io/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
+| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://goerli.etherscan.io/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
+| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://goerli.etherscan.io/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
 
 </TabItem>
 
@@ -178,8 +178,8 @@ Below is a list of the V2Factory and V2Router02 contracts deployed.
 
 | Name | Address | Source Code | Explorer |
 | :-- | :-- | :-- | :-- |
-| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol) | [Link](https://gnosisscan.io/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
-| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) | [Link](https://gnosisscan.io/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
+| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://gnosisscan.io/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
+| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://gnosisscan.io/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
 
 </TabItem>
 
@@ -189,8 +189,8 @@ Below is a list of the V2Factory and V2Router02 contracts deployed.
 
 | Name | Address | Source Code | Explorer |
 | :-- | :-- | :-- | :-- |
-| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol) | [Link](https://explorer.harmony.one/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
-| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) | [Link](https://explorer.harmony.one/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
+| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://explorer.harmony.one/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
+| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://explorer.harmony.one/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
 
 </TabItem>
 
@@ -200,8 +200,8 @@ Below is a list of the V2Factory and V2Router02 contracts deployed.
 
 | Name | Address | Source Code | Explorer |
 | :-- | :-- | :-- | :-- |
-| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol) | [Link](https://explorer.testnet.harmony.one/address/0xc35dadb65012ec5796536bd9864ed8773abc74c4) |
-| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) | [Link](https://explorer.testnet.harmony.one/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
+| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://explorer.testnet.harmony.one/address/0xc35dadb65012ec5796536bd9864ed8773abc74c4) |
+| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://explorer.testnet.harmony.one/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
 
 </TabItem>
 
@@ -211,8 +211,8 @@ Below is a list of the V2Factory and V2Router02 contracts deployed.
 
 | Name | Address | Source Code | Explorer |
 | :-- | :-- | :-- | :-- |
-| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol) | [Link](https://www.hecoinfo.com/en-us/address/0xc35dadb65012ec5796536bd9864ed8773abc74c4) |
-| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) | [Link](https://www.hecoinfo.com/en-us/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
+| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://www.hecoinfo.com/en-us/address/0xc35dadb65012ec5796536bd9864ed8773abc74c4) |
+| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://www.hecoinfo.com/en-us/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
 
 </TabItem>
 
@@ -222,8 +222,8 @@ Below is a list of the V2Factory and V2Router02 contracts deployed.
 
 | Name | Address | Source Code | Explorer |
 | :-- | :-- | :-- | :-- |
-| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol) | [Link](https://testnet.hecoinfo.com/en-us/address/0xc35dadb65012ec5796536bd9864ed8773abc74c4) |
-| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) | [Link](https://testnet.hecoinfo.com/en-us/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
+| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://testnet.hecoinfo.com/en-us/address/0xc35dadb65012ec5796536bd9864ed8773abc74c4) |
+| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://testnet.hecoinfo.com/en-us/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
 
 </TabItem>
 
@@ -233,8 +233,8 @@ Below is a list of the V2Factory and V2Router02 contracts deployed.
 
 | Name | Address | Source Code | Explorer |
 | :-- | :-- | :-- | :-- |
-| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol) | [Link](https://moonscan.io/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
-| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) | [Link](https://moonscan.io/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
+| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://moonscan.io/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
+| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://moonscan.io/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
 
 </TabItem>
 
@@ -244,8 +244,8 @@ Below is a list of the V2Factory and V2Router02 contracts deployed.
 
 | Name | Address | Source Code | Explorer |
 | :-- | :-- | :-- | :-- |
-| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol) | [Link](https://moonriver.moonscan.io/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
-| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) | [Link](https://moonriver.moonscan.io/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
+| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://moonriver.moonscan.io/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
+| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://moonriver.moonscan.io/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
 
 </TabItem>
 
@@ -255,8 +255,8 @@ Below is a list of the V2Factory and V2Router02 contracts deployed.
 
 | Name | Address | Source Code | Explorer |
 | :-- | :-- | :-- | :-- |
-| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol) | [Link](https://mumbai.polygonscan.com/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
-| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) | [Link](https://mumbai.polygonscan.com/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
+| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://mumbai.polygonscan.com/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
+| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://mumbai.polygonscan.com/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
 
 </TabItem>
 
@@ -266,8 +266,8 @@ Below is a list of the V2Factory and V2Router02 contracts deployed.
 
 | Name | Address | Source Code | Explorer |
 | :-- | :-- | :-- | :-- |
-| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol) | [Link](https://www.okx.com/explorer/oktc/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
-| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) | [Link](https://www.okx.com/explorer/oktc/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
+| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://www.okx.com/explorer/oktc/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
+| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://www.okx.com/explorer/oktc/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
 
 </TabItem>
 
@@ -277,8 +277,8 @@ Below is a list of the V2Factory and V2Router02 contracts deployed.
 
 | Name | Address | Source Code | Explorer |
 | :-- | :-- | :-- | :-- |
-| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol) | [Link](https://www.oklink.com/oktc-test/tokenAddr/0xc35dadb65012ec5796536bd9864ed8773abc74c4) |
-| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) | [Link](https://www.oklink.com/oktc-test/tokenAddr/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
+| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://www.oklink.com/oktc-test/tokenAddr/0xc35dadb65012ec5796536bd9864ed8773abc74c4) |
+| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://www.oklink.com/oktc-test/tokenAddr/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
 
 </TabItem>
 
@@ -288,8 +288,8 @@ Below is a list of the V2Factory and V2Router02 contracts deployed.
 
 | Name | Address | Source Code | Explorer |
 | :-- | :-- | :-- | :-- |
-| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol) | [Link](https://explorer.palm.io/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
-| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) | [Link](https://explorer.palm.io/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
+| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://explorer.palm.io/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
+| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://explorer.palm.io/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
 
 </TabItem>
 
@@ -299,8 +299,8 @@ Below is a list of the V2Factory and V2Router02 contracts deployed.
 
 | Name | Address | Source Code | Explorer |
 | :-- | :-- | :-- | :-- |
-| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol) | [Link](https://polygonscan.com/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
-| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) | [Link](https://polygonscan.com/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
+| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://polygonscan.com/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
+| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://polygonscan.com/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
 
 </TabItem>
 
@@ -310,8 +310,8 @@ Below is a list of the V2Factory and V2Router02 contracts deployed.
 
 | Name | Address | Source Code | Explorer |
 | :-- | :-- | :-- | :-- |
-| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.sol) | [Link](https://www.teloscan.io/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
-| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol) | [Link](https://www.teloscan.io/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
+| `V2Factory` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Factory.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://www.teloscan.io/address/0xc35DADB65012eC5796536bD9864eD8773aBc74C4) |
+| `V2Router02` | `0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506` | [Code](https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol) | [Link](https://www.teloscan.io/address/0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506) |
 
 </TabItem>
 


### PR DESCRIPTION
Replaces 29 occurrences:  

 ~"https://github.com/sushiswap/sushiswap/blob/master/protocols/sushiswap/contracts/UniswapV2Router02.sol"~ 
 "https://github.com/sushiswap/v2-core/blob/master/contracts/UniswapV2Router02.sol"

Former being outdated.